### PR TITLE
Feat/added page context to slider

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -25,11 +25,11 @@ function init(){
         /**
          * store the current slider context under the slider's id
          */
-        var slidersContext = Object.assign(existingPageContext.sliders || {}, {
+        var slidersContext = _.assign(existingPageContext.sliders || {}, {
           [id]: swiper.activeIndex
         });
 
-        Fliplet.Page.Context.set(Object.assign(existingPageContext, slidersContext))
+        Fliplet.Page.Context.set(_.assign(existingPageContext, slidersContext))
       }
     });
 

--- a/js/build.js
+++ b/js/build.js
@@ -18,7 +18,7 @@ function init(){
         /**
          * get current page context if any
          */
-        var existingPageContext = Fliplet.Env.get('pageContext') || {};
+        var existingPageContext = Fliplet.Page.Context.get() || {};
         /**
          * use a direct access data structure for faster lookup later
          */
@@ -29,7 +29,7 @@ function init(){
           [id]: swiper.activeIndex
         });
 
-        Fliplet.Env.set('pageContext', Object.assign(existingPageContext, slidersContext));
+        Fliplet.Page.Context.set(Object.assign(existingPageContext, slidersContext))
       }
     });
 

--- a/js/build.js
+++ b/js/build.js
@@ -21,15 +21,13 @@ function init(){
         var existingPageContext = Fliplet.Page.Context.get() || {};
         /**
          * use a direct access data structure for faster lookup later
-         */
-        /**
          * store the current slider context under the slider's id
          */
         var slidersContext = _.assign(existingPageContext.sliders || {}, {
           [id]: swiper.activeIndex
         });
 
-        Fliplet.Page.Context.set(_.assign(existingPageContext, slidersContext))
+        Fliplet.Page.Context.set(_.assign(existingPageContext, slidersContext));
       }
     });
 
@@ -43,7 +41,8 @@ function init(){
       if(pageContext && pageContext[id]){
         swiper.slideTo(pageContext[id]);
       }
-    })
+    });
+
     $(container).find('.ob-skip span').click(function () {
       var data = Fliplet.Widget.getData( $(this).parents('.onboarding-holder').data('onboarding-id') );
 

--- a/js/build.js
+++ b/js/build.js
@@ -1,5 +1,4 @@
 function init(){
-
   $('[data-onboarding-id]').each(function(){
     var container = this;
     var id = $(container).data('onboarding-id');

--- a/js/build.js
+++ b/js/build.js
@@ -15,7 +15,7 @@ function init(){
       nextButton: '.swiper-button-next-' + id,
       prevButton: '.swiper-button-prev-' + id,
       grabCursor: true,
-      onSlideNextEnd: function () {
+      onSlideChangeEnd: function () {
         /**
          * get current page context if any
          */
@@ -29,7 +29,7 @@ function init(){
         var slidersContext = Object.assign(existingPageContext.sliders || {}, {
           [id]: swiper.activeIndex
         });
-        
+
         Fliplet.Env.set('pageContext', Object.assign(existingPageContext, slidersContext));
       }
     });

--- a/js/build.js
+++ b/js/build.js
@@ -1,4 +1,5 @@
 function init(){
+
   $('[data-onboarding-id]').each(function(){
     var container = this;
     var id = $(container).data('onboarding-id');
@@ -13,7 +14,24 @@ function init(){
       paginationClickable: true,
       nextButton: '.swiper-button-next-' + id,
       prevButton: '.swiper-button-prev-' + id,
-      grabCursor: true
+      grabCursor: true,
+      onSlideNextEnd: function () {
+        /**
+         * get current page context if any
+         */
+        var existingPageContext = Fliplet.Env.get('pageContext') || {};
+        /**
+         * use a direct access data structure for faster lookup later
+         */
+        /**
+         * store the current slider context under the slider's id
+         */
+        var slidersContext = Object.assign(existingPageContext.sliders || {}, {
+          [id]: swiper.activeIndex
+        });
+        
+        Fliplet.Env.set('pageContext', Object.assign(existingPageContext, slidersContext));
+      }
     });
 
     swiper.update();
@@ -22,6 +40,11 @@ function init(){
       swiper.update();
     });
 
+    Fliplet.Hooks.on('restorePageContext', function (pageContext) {
+      if(pageContext && pageContext[id]){
+        swiper.slideTo(pageContext[id]);
+      }
+    })
     $(container).find('.ob-skip span').click(function () {
       var data = Fliplet.Widget.getData( $(this).parents('.onboarding-holder').data('onboarding-id') );
 


### PR DESCRIPTION
Ref. Fliplet/fliplet-studio#3594
We will now store the active index of each slider on a page per each slide change.
This will be later restored through our new `pageContext` API which was added [here](https://github.com/Fliplet/fliplet-api/pull/3086).