### PR TITLE
Placeholder in IE now will display as placeholder not a default value

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -240,7 +240,7 @@
               <label for="list-item-desc-\{{id}}">Description</label>
             </div>
             <div class="col-sm-8">
-              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}" placeholder="Enter description" rows="3"></textarea>
+              <textarea class="form-control list-item-desc" id="list-item-desc-\{{id}}" name="list-item-desc-\{{id}}"  rows="3"></textarea>
             </div>
           </div>
 

--- a/js/interface.js
+++ b/js/interface.js
@@ -302,6 +302,7 @@ var FlSlider = (function() {
       var $newPanel = $(Handlebars.panelTemplate(data));
       $accordionContainer.append($newPanel);
 
+      $newPanel.find('.form-control.list-item-desc').attr('placeholder', 'Enter description');
       $newPanel.find('.form-control:eq(0)').select();
       $('form.form-horizontal').stop().animate({
         scrollTop: $('.tab-content').height()


### PR DESCRIPTION
@tonytlwu @squallstar @sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5060

## Description
Placeholder in IE now will display as a placeholder, not a default value

## Screenshots/screencasts
![issue-5060](https://user-images.githubusercontent.com/53430352/68454998-ee559e00-0202-11ea-81fb-2028e5ab6e04.gif)

## Backward compatibility

This change is fully backward compatible.

## Notes
As I understand this issue is within IE itself. According to this [issue](https://github.com/vuejs/vue/issues/7138) to prevent it from happening we need just to prevent initial input events, but in our case enough to add placeholder after we create a template.