### PR TITLE
Show slider when we creating a web app

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -78,7 +78,7 @@
 }
 
 .swiper-container {
-	width: 100%;
+	width: 95vw;
 }
 
 .swiper-wrapper {


### PR DESCRIPTION
@sofiiakvasnevska 
## Issue
https://github.com/Fliplet/fliplet-studio/issues/5149

## Description
Show slider when we creating a web app

## Screenshots/screencasts
![5149](https://user-images.githubusercontent.com/53430352/69956692-5731ec80-1509-11ea-9850-73f6abffdd9f.gif)

Native app
![photo5416096946331954030](https://user-images.githubusercontent.com/53430352/69956969-3918bc00-150a-11ea-9604-ba974441e533.jpg)


## Backward compatibility

This change is fully backward compatible.

## Notes
This issue occurs only in the single-column layout. As I understand because this layout doesn't have a given width slider takes width more that one screen so I change the width from 100% to 95vw.