### PR TITLE
Show slider on the tablet resolution and after web publish

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -78,7 +78,7 @@
 }
 
 .swiper-container {
-	width: 100%;
+	width: 100vw;
 }
 
 .swiper-wrapper {
@@ -130,12 +130,14 @@
 }
 
 .onboarding-content .swiper-button-prev {
-	left: 0;
+	/* Using 10px so the arrow wouldn't hide behind the edge */
+	left: 10px;
 	text-align: left;
 }
 
 .onboarding-content .swiper-button-next {
-	right: 0;
+	/* Using 10px so the arrow wouldn't hide behind the edge */
+	right: 10px;
 	text-align: right;
 }
 


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/5465

## Description
Show slider on the tablet resolution and after web publish

## Screenshots/screencasts
### Preview
Before
![Slider was](https://user-images.githubusercontent.com/53430352/73645774-a1a62580-4680-11ea-8d65-3b11ff89fee6.png)

After
![Slider now](https://user-images.githubusercontent.com/53430352/73645778-a5d24300-4680-11ea-95e2-53c22f94c569.png)

### Web App
Before
![image](https://user-images.githubusercontent.com/53430352/73646195-9273a780-4681-11ea-9ddc-a02f753a65ec.png)

After
![image](https://user-images.githubusercontent.com/53430352/73646221-a4554a80-4681-11ea-8e4f-65a582250170.png)

### Native device
Before
![image](https://user-images.githubusercontent.com/53430352/73646327-e088ab00-4681-11ea-919a-f61fd366823f.png)

After
![image](https://user-images.githubusercontent.com/53430352/73646345-ec746d00-4681-11ea-9d4b-f8201f2ebcfc.png)

## Backward compatibility

This change is fully backward compatible.

## Notes
This issue occurred because of the SwiperJS lib.
As you may see on the screenshots when we set `.swiper-container` to the `100%` it gives the slide a very large width and when we change it to `100vw` it will give us a correct slide width but now to show arrows correctly we need to give them a `10px` indent from the edge.