### PR TITLE
Navigation arrow now have lower index then menus

### DIFF
--- a/css/build.css
+++ b/css/build.css
@@ -123,7 +123,7 @@
 	height: 48px;
 	margin: -24px 0 0;
 	cursor: default;
-	z-index: 10;
+	z-index: 9;
 	line-height: 48px;
 	font-size: 48px;
 	color: #999999;


### PR DESCRIPTION
@sofiiakvasnevska 

## Issue
https://github.com/Fliplet/fliplet-studio/issues/1048

## Description
Lowered navigation arrows z-index from 10 to 9. All menus have z-index 10.

## Screenshots/screencasts
![slider-z-index](https://user-images.githubusercontent.com/52824207/74021271-e80ec380-49a3-11ea-8cc6-75bebdc7b62b.gif)

## Backward compatibility
This change is fully backward compatible.